### PR TITLE
Fix case sensitive names in MakefileGame

### DIFF
--- a/MakefileGame
+++ b/MakefileGame
@@ -95,8 +95,8 @@ LIBS=  -lNoisepp -lpspaudiolib -lpspaudio -lmikmod -lmmio -lpspaudiocodec -lpng 
 
 EXTRA_TARGETS = EBOOT.PBP
 PSP_EBOOT_TITLE = Minecraft
-PSP_EBOOT_ICON = ICON0.png
-PSP_EBOOT_PIC1 = PIC1.png
+PSP_EBOOT_ICON = ICON0.PNG
+PSP_EBOOT_PIC1 = PIC1.PNG
 
 PSPSDK=$(shell psp-config --pspsdk-path)
 include $(PSPSDK)/lib/build.mak


### PR DESCRIPTION
I was getting file not found issues because I pulled the png's with the extension as PNG but the make was wanting lowercase png. Figured this is easier than renaming files.